### PR TITLE
Utilizando directamente el modelo para mostrar el número de usuarios

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -22,7 +22,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        View::share('userCount', User::count());
+        //
     }
 
 }

--- a/resources/views/dopetrope/partials/footer.blade.php
+++ b/resources/views/dopetrope/partials/footer.blade.php
@@ -17,7 +17,7 @@
                     <br>
                     <br>
                     <p style="font-size: 10em;">
-                        {{$userCount}}
+                        {{ \App\Models\User::count() }}
                     </p>
                 </section>
             </div>


### PR DESCRIPTION
El código del archivo `app/Providers/AppServiceProvider.php` 
```
     public function boot(): void
     {
       View::share('userCount', User::count());
     }
 
```
generaba errores en una instalación limpia de la aplicación.

Este código se utilizaba en el `resources/views/dopetrope/partials/footer.blade.php` en el que ha habido que sustituir
```
{{$userCount}}
```
por
```
{{ \App\Models\User::count() }}
```